### PR TITLE
Introduce EksekResult class

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 
 ### Basic usage
 
-Use the `Eksek.ute` to execute a command:
+Use the `eksek` to execute a command:
 
 ```ruby
-Eksek.ute 'echo Hello'
+eksek 'echo Hello'
 ```
 
 This returns a result object (*EksekResult*) providing the following methods:
@@ -22,11 +22,14 @@ This returns a result object (*EksekResult*) providing the following methods:
 - `success?` returns `true` or `false` depending of the exit code (`0` for `true`).
 - `success!` throws an exception if the command exited with a non-0 code.
 
-The `success!` method can be chained with any other of the above ones to have a "fail or return" like so:
+The `success!` method can be chained with any other of the above ones and it is wrapped in the convenience method `eksek!` to have a "fail or return" like so:
 
 ```ruby
-r = Eksek.ute 'echo Hello'
-puts r.success!.stdout # Hello
+puts eksek!('echo Hello').stdout # Hello
+
+# The above is essentially the same as:
+
+puts eksek('echo Hello').success!.stdout
 ```
 
 ### Writing to stdin
@@ -34,17 +37,17 @@ puts r.success!.stdout # Hello
 To write into the standard input a block can be used:
 
 ```ruby
-r = Eksek.ute('read A; echo $A') { |stdin| stdin.write "Hello" }
+r = eksek('read A; echo $A') { |stdin| stdin.write "Hello" }
 r.success!
 ```
 
 If the block returns a `String` or `IO`, it will be written into the stdio.
 
 ```ruby
-r = Eksek('read A; echo $A') { "Hello" }
+r = eksek('read A; echo $A') { "Hello" }
 r.success!
 
-r = Eksek('read A; echo $A') { File.open('myfile.txt') }
+r = eksek('read A; echo $A') { File.open('myfile.txt') }
 r.success!
 ```
 
@@ -56,13 +59,21 @@ The run method can accept a hash of options, according to `Process::spawn`.
 Additionally, a hash passed as `:env` will have its keys stringified, so that symbols can be used to. For example:
 
 ```ruby
-r = Eksek.ute 'echo $A', env: {A: "Hello"}
+r = eksek 'echo $A', env: {A: "Hello"}
 r.stdout # Hello
 
-r = Eksek.ute 'echo $PWD', chdir: '/tmp'
+r = eksek 'echo $PWD', chdir: '/tmp'
 r.stdout # /tmp
 ```
 
-### Trivia
+### Further information
 
-`Eksek.ute` is also aliased as `Eksek.run`. In case you prefer a more conservative naming, everything just works the same.
+In case you prefer an object oriented method, you can also use the `Eksektuter` class that is used by the `eksek` method directly. The following examples are basically the same:
+
+```ruby
+eksek 'echo Hello'
+```
+
+```ruby
+Esekuter.new 'echo Hello'
+```

--- a/README.md
+++ b/README.md
@@ -6,31 +6,27 @@
 
 ## Features
 
-### Basic methods
+### Basic usage
+
+Use the `Eksek.ute` to execute a command:
+
+```ruby
+Eksek.ute 'echo Hello'
+```
+
+This returns a result object (*EksekResult*) providing the following methods:
 
 - `exit` returns the exit code.
 - `stdout` returns the standard output as a string.
 - `stderr` returns the standard error as a string.
-- `stdouterr` returns the standard output and error in a single string.
 - `success?` returns `true` or `false` depending of the exit code (`0` for `true`).
 - `success!` throws an exception if the command exited with a non-0 code.
 
-For example
+The `success!` method can be chained with any other of the above ones to have a "fail or return" like so:
 
 ```ruby
-puts Eksek.stdout 'echo Hello' # Hello
-```
-
-### Chaining methods together
-
-Any of the above methods can be chained in almost any order, except `success?` and `success!`, which can only occur at the end of the method; and `stdout` and `stderr` cannot be used together with `stdouterr`.
-
-For example:
-
-```ruby
-stdout, stderr = Eksek.stdout_stderr_success! 'echo Hello; echo World >&2'
-puts stdout # Hello
-puts stderr # World
+r = Eksek.ute 'echo Hello'
+puts r.success!.stdout # Hello
 ```
 
 ### Writing to stdin
@@ -38,25 +34,35 @@ puts stderr # World
 To write into the standard input a block can be used:
 
 ```ruby
-Eksek.success! 'read A; echo $A' { |stdin| stdin.write "Hello" }
+r = Eksek.ute('read A; echo $A') { |stdin| stdin.write "Hello" }
+r.success!
 ```
 
 If the block returns a `String` or `IO`, it will be written into the stdio.
 
 ```ruby
-Eksek.success! 'read A; echo $A' { "Hello" }
-Eksek.success! 'read A; echo $A' { File.open('myfile.txt') }
+r = Eksek('read A; echo $A') { "Hello" }
+r.success!
+
+r = Eksek('read A; echo $A') { File.open('myfile.txt') }
+r.success!
 ```
 
 
 ### Passing other options
 
-Any of those methods can accept a hash of options, according to `Process::spawn`.
+The run method can accept a hash of options, according to `Process::spawn`.
 
 Additionally, a hash passed as `:env` will have its keys stringified, so that symbols can be used to. For example:
 
 ```ruby
-Eksek.stdout 'echo $A', env: {A: "Hello"} # Hello
+r = Eksek.ute 'echo $A', env: {A: "Hello"}
+r.stdout # Hello
 
-Eksek.stdout 'echo $PWD', chdir: '/tmp' # /tmp
+r = Eksek.ute 'echo $PWD', chdir: '/tmp'
+r.stdout # /tmp
 ```
+
+### Trivia
+
+`Eksek.ute` is also aliased as `Eksek.run`. In case you prefer a more conservative naming, everything just works the same.

--- a/lib/eksek.rb
+++ b/lib/eksek.rb
@@ -1,30 +1,18 @@
 # frozen_string_literal: true
 
-require 'open3'
-
-require_relative 'eksek_error'
 require_relative 'eksekuter'
 
 # Executes shell commands and can be specified to return the standard output,
 # standard error, etc.
 # Accepts the same options as Process.spawn e.g. :chdir, :env.
-class Eksek
-  class << self
-    def run cmd, opts = {}, &block
-      verify cmd, opts
+module Kernel
+  private
 
-      Eksekuter.new(cmd, opts).run(&block)
-    end
+  def eksek cmd, opts = {}, &block
+    Eksekuter.new(cmd, opts).run(&block)
+  end
 
-    alias ute run
-
-    private
-
-    def verify cmd, opts
-      raise TypeError, 'Command must be a string' unless cmd.is_a? String
-      expected_hash_message = 'Expected options to be a Hash'
-      has_invalid_opts = !opts.is_a?(Hash)
-      raise TypeError, expected_hash_message if has_invalid_opts
-    end
+  def eksek! cmd, opts = {}, &block
+    eksek(cmd, opts, &block).success!
   end
 end

--- a/lib/eksek.rb
+++ b/lib/eksek.rb
@@ -9,50 +9,22 @@ require_relative 'eksekuter'
 # standard error, etc.
 # Accepts the same options as Process.spawn e.g. :chdir, :env.
 class Eksek
-  ALLOWED_METHODS = %i[
-    exit stdout stderr stdouterr success? success!
-  ].freeze
-
   class << self
-    def respond_to_missing? name, include_private
-      method_name_valid?(name) || super
+    def run cmd, opts = {}, &block
+      verify cmd, opts
+
+      Eksekuter.new(cmd, opts).run(&block)
     end
 
-    def method_missing symbol, *args, &block
-      return super unless method_name_valid? symbol
-      methods = symbol.to_s.split('_').map(&:to_sym)
-      cmd, opts = validate_args(args)
-      Eksekuter.new(methods, cmd, opts).run(&block)
-    end
+    alias ute run
 
-    def method_name_valid? name
-      methods = name.to_s.split('_').map(&:to_sym)
-      methods.all? { |m| ALLOWED_METHODS.include? m }
-    end
+    private
 
-    def validate_conflicting_methods methods
-      methods_are_conflicting =
-        if methods.include? :stdouterr
-          methods.include?(:stderr) || methods.include?(:stdout)
-        else
-          true
-        end
-      error_message = 'Cannot call stdouterr with either stdout or stderr'
-      raise EksekError, error_message if methods_are_conflicting
-    end
-
-    # @return an array of a String and a Hash, representing the command and the
-    # opts
-    def validate_args args
-      raise EksekError, 'Must provide at least a command' if args.empty?
-
-      cmd = args[0]
+    def verify cmd, opts
       raise TypeError, 'Command must be a string' unless cmd.is_a? String
-      expected_hash_message = 'Expected argument 2 to be a Hash'
-      has_invalid_opts = args.length > 1 && !args[1].is_a?(Hash)
+      expected_hash_message = 'Expected options to be a Hash'
+      has_invalid_opts = !opts.is_a?(Hash)
       raise TypeError, expected_hash_message if has_invalid_opts
-      opts = args[1] || {}
-      [cmd, opts]
     end
   end
 end

--- a/lib/eksek_result.rb
+++ b/lib/eksek_result.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative 'eksek_result'
+
+# Describes a result object to be used for evaluating
+# return values from a command
+class EksekResult
+  def initialize cmd, exit_code, success, stdout, stderr
+    @cmd = cmd
+    @exit_code = exit_code
+    @success = success
+    @stdout = stdout
+    @stderr = stderr
+  end
+
+  attr_reader :exit_code, :stdout, :stderr
+
+  def success?
+    @success
+  end
+
+  def success!
+    raise EksekError, "Command failed: #{@cmd.inspect}" unless success?
+    self
+  end
+end

--- a/lib/eksek_result.rb
+++ b/lib/eksek_result.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'eksek_result'
+require_relative 'eksek_error'
 
 # Describes a result object to be used for evaluating
 # return values from a command

--- a/lib/eksekuter.rb
+++ b/lib/eksekuter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 require_relative 'eksek_result'
 
 # Class that command execution is delegated to by Eksek.

--- a/spec/eksek_spec.rb
+++ b/spec/eksek_spec.rb
@@ -4,52 +4,52 @@ require 'tempfile'
 
 require 'eksek'
 
-RSpec.describe Eksek, '#success?' do
+RSpec.describe 'eksek#success?' do
   it 'returns true or false' do
-    expect(Eksek.ute('true').success?).to be(true)
-    expect(Eksek.ute('exit 1').success?).to be(false)
+    expect(eksek('true').success?).to be(true)
+    expect(eksek('exit 1').success?).to be(false)
   end
 end
 
-RSpec.describe Eksek, '#success!' do
-  it 'fails on :success! when appropriatly' do
-    expect { Eksek.ute('true').success! }.not_to raise_error
-    expect { Eksek.ute('exit 1').success! }.to raise_error EksekError
+RSpec.describe '#eksek!' do
+  it 'fails on :eksek! when appropriatly' do
+    expect { eksek! 'true' }.not_to raise_error
+    expect { eksek! 'exit 1' }.to raise_error EksekError
   end
 end
 
-RSpec.describe Eksek, '#exit' do
+RSpec.describe 'eksek#exit' do
   it 'returns the exit code' do
-    expect(Eksek.ute('exit 0').exit_code).to be(0)
-    expect(Eksek.ute('exit 1').exit_code).to be(1)
-    expect(Eksek.ute('exit 7').exit_code).to be(7)
+    expect(eksek('exit 0').exit_code).to be(0)
+    expect(eksek('exit 1').exit_code).to be(1)
+    expect(eksek('exit 7').exit_code).to be(7)
   end
 end
 
-RSpec.describe 'Eksek#stdout, Eksek#stderr' do
+RSpec.describe 'eksek#stdout, eksek#stderr' do
   it 'captures the stdout and stderr separately' do
-    expect(Eksek.ute('echo Hello').stdout).to eq('Hello')
-    expect(Eksek.ute('echo Hello >&2').stderr).to eq('Hello')
+    expect(eksek('echo Hello').stdout).to eq('Hello')
+    expect(eksek('echo Hello >&2').stderr).to eq('Hello')
   end
 end
 
-RSpec.describe 'Eksek#stdout, Eksek#stderr, Eksek#exit_code, Eksek#success!' do
-  it 'lets you combine success! and stdout/stderr/exit_code' do
-    expect(Eksek.ute('echo Hello').success!.stdout).to eq('Hello')
-    expect(Eksek.ute('echo Hello >&2').success!.stderr).to eq('Hello')
-    expect(Eksek.ute('exit 0').success!.exit_code).to be(0)
-    expect { Eksek.ute('exit 1').success!.stdout }.to raise_error EksekError
+RSpec.describe 'eksek#stdout, eksek#stderr, eksek#exit_code, eksek!' do
+  it 'lets you combine eksek! and stdout/stderr/exit_code' do
+    expect(eksek!('echo Hello').stdout).to eq('Hello')
+    expect(eksek!('echo Hello >&2').stderr).to eq('Hello')
+    expect(eksek!('exit 0').exit_code).to be(0)
+    expect { eksek!('exit 1').stdout }.to raise_error EksekError
   end
 end
 
 RSpec.describe 'Standard input' do
   it 'accepts a block where the stdin can be written to' do
-    o = Eksek.ute('read A B; echo $A, $B') { |i| i.write('Hi world') }
+    o = eksek('read A B; echo $A, $B') { |i| i.write('Hi world') }
     expect(o.stdout).to eq('Hi, world')
   end
 
   it 'reads a String that the block returns' do
-    o = Eksek.ute('read A; echo $A') { 'Hello' }
+    o = eksek('read A; echo $A') { 'Hello' }
     expect(o.stdout).to eq('Hello')
   end
 
@@ -59,17 +59,10 @@ RSpec.describe 'Standard input' do
     file.close
 
     File.open(file.path) do |f|
-      o = Eksek.ute('read A; echo $A!!!') { f }
+      o = eksek('read A; echo $A!!!') { f }
       expect(o.stdout).to eq('Hello!!!')
     end
 
     file.unlink
-  end
-end
-
-RSpec.describe Eksek, '#run' do
-  it 'lets you use either Eksek.ute or Eksek.run' do
-    expect(Eksek.ute('true').success?).to be(Eksek.run('true').success?)
-    expect(Eksek.ute('exit 1').success?).to be(Eksek.run('exit 1').success?)
   end
 end

--- a/spec/eksek_spec.rb
+++ b/spec/eksek_spec.rb
@@ -54,11 +54,16 @@ RSpec.describe 'Standard input' do
   end
 
   it 'reads an IO that the block returns' do
-    Tempfile.open do |f|
-      f.write('Hello')
-      o = Eksek.ute("cat #{f.path}") { f }
-      expect(o.stdout).to eq('Hello')
+    file = Tempfile.open
+    file.write('Hello')
+    file.close
+
+    File.open(file.path) do |f|
+      o = Eksek.ute('read A; echo $A!!!') { f }
+      expect(o.stdout).to eq('Hello!!!')
     end
+
+    file.unlink
   end
 end
 


### PR DESCRIPTION
This introduces a new class `EksekResult` that would handle the output as suggested in #4. Most of the functionality works exactly the same, but there's a `run` method now for Eksek which returns an `EksekResult` in the end.

This exposes the following methods (which work similar to the previous ones):

* stdin
* stdout
* exit_code
* success?
* success!

⚠️ Heads up:

* `success!` will throw the EksekError as before in case not successful
* `success!` will return `self` (the EksekResult) in case everything is fine, thus making it possible to combine this with all the other methods
* Unfortunately a combined stdin+stderr result would not work anymore like this (any ideas about that??)

### Todo 

- [x] Remove getters for stdout and stderr from ExecResult and add to attr_reader
- [x] Rename `run` method (maybe keep an alias?)
- [x] Remove initialisation with `nil` of stdout and stderr in Eksekuter
- [x] Update Readme
