### PR TITLE
Implement to_s for EksekResult

### DIFF
--- a/lib/eksek_result.rb
+++ b/lib/eksek_result.rb
@@ -26,4 +26,8 @@ class EksekResult
     raise EksekError, "Command failed: #{@cmd.inspect}" unless success?
     self
   end
+
+  def to_s
+    stdout
+  end
 end

--- a/spec/eksek_spec.rb
+++ b/spec/eksek_spec.rb
@@ -101,3 +101,11 @@ RSpec.describe 'Kernel#spawn-style parameters' do
     expect(result.stdout).to eq('Hello World')
   end
 end
+
+RSpec.describe 'EksekResult#to_s' do
+  it 'returns the stdout' do
+    command = 'echo HelloStdout && echo HelloStderr >&2'
+    output = "The output was: #{Eksekuter.new(command).run}."
+    expect(output).to eq('The output was: HelloStdout.')
+  end
+end


### PR DESCRIPTION
This implements the suggestion from #9 and overrides the `to_s` method from EksekResult to give a more meaningful output. In this version it just returns the stdout.

The `inspect` method was not overridden as the default seems to be good enough.